### PR TITLE
patch: add support for chdir into unicode path on windows

### DIFF
--- a/include/patch/options.h
+++ b/include/patch/options.h
@@ -25,7 +25,7 @@ struct Options {
     // posix defined options
     bool save_backup { false };
     bool interpret_as_context { false };
-    std::string patch_directory_path;
+    std::filesystem::path patch_directory_path;
     std::string define_macro;
     bool interpret_as_ed { false };
     std::filesystem::path patch_file_path;

--- a/src/cmdline.cpp
+++ b/src/cmdline.cpp
@@ -215,7 +215,7 @@ const Options& CmdLineParser::parse()
         if (parse_path('i', "--input", m_options.patch_file_path))
             continue;
 
-        if (parse_string('d', "--directory", m_options.patch_directory_path))
+        if (parse_path('d', "--directory", m_options.patch_directory_path))
             continue;
 
         if (parse_string('D', "--ifdef", m_options.define_macro))

--- a/tests/test_full.py
+++ b/tests/test_full.py
@@ -1411,6 +1411,35 @@ index de98044..0f673f8 100644
         self.assertEqual(ret.stdout, 'patching file 1\n')
         self.assertEqual(ret.stderr, '')
 
+    def test_chdir_unicode_(self):
+        ''' test using chdir with non ascii '''
+
+        os.mkdir('गिलास')
+        patch = '''
+--- 1	2022-06-26 11:17:58.948060133 +1200
++++ 2	2022-06-26 11:18:03.500001858 +1200
+@@ -1,3 +1,2 @@
+ 1
+-2
+ 3
+'''
+        with open(os.path.join('गिलास', 'diff.patch'), 'w') as patch_file:
+            patch_file.write(patch)
+
+        to_patch = '''1
+2
+3
+'''
+        with open(os.path.join('गिलास', '1'), 'w') as to_patch_file:
+            to_patch_file.write(to_patch)
+
+        ret = run_patch('patch -i diff.patch -d गिलास')
+
+        self.assertEqual(ret.stderr, '')
+        self.assertEqual(ret.returncode, 0)
+        self.assertEqual(ret.stdout, 'patching file 1\n')
+
+
     def test_add_executable_bit(self):
         ''' test that a patch changing mode applies '''
 


### PR DESCRIPTION
Further extend the support which was added in the previous commit.