### PR TITLE
path: add initial support for patching unicode paths on windows

### DIFF
--- a/include/patch/cmdline.h
+++ b/include/patch/cmdline.h
@@ -50,7 +50,6 @@ public:
     const Options& parse();
 
 private:
-    bool parse_path(char short_opt, const char* long_opt, std::filesystem::path& option);
     bool parse_string(char short_opt, const char* long_opt, std::string& option);
     bool parse_int(char short_opt, const char* long_opt, int& option);
 

--- a/include/patch/options.h
+++ b/include/patch/options.h
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include <filesystem>
 #include <string>
 
 namespace Patch {
@@ -25,10 +24,10 @@ struct Options {
     // posix defined options
     bool save_backup { false };
     bool interpret_as_context { false };
-    std::filesystem::path patch_directory_path;
+    std::string patch_directory_path;
     std::string define_macro;
     bool interpret_as_ed { false };
-    std::filesystem::path patch_file_path;
+    std::string patch_file_path;
     bool ignore_whitespace { false };
     bool interpret_as_normal { false };
     bool ignore_reversed { false };

--- a/include/patch/patch.h
+++ b/include/patch/patch.h
@@ -15,7 +15,7 @@ struct PatchHeaderInfo;
 
 std::string to_string(Format format);
 
-void print_header_info(std::istream& patch, PatchHeaderInfo& header_info, std::ostream& out);
+void print_header_info(std::istream& patch, const PatchHeaderInfo& header_info, std::ostream& out);
 
 enum class Default {
     True,

--- a/include/patch/system.h
+++ b/include/patch/system.h
@@ -21,17 +21,33 @@ bool get_line(std::istream& is, std::string& line, NewLine* newline = nullptr);
 
 std::string read_tty_until_enter();
 
-void chdir(const std::filesystem::path& path);
+void chdir(const std::string& path);
 
-bool remove_empty_directory(const std::filesystem::path& path);
+void remove_file_and_empty_parent_folders(const std::string& path);
 
-void remove_file_and_empty_parent_folders(std::filesystem::path path);
+void ensure_parent_directories(const std::string& path);
+
+bool file_exists(const std::string& path);
+
+bool is_regular_file(const std::string& path);
 
 #ifdef _WIN32
 
 std::wstring to_wide(const std::string& str);
 
 std::string to_narrow(const std::wstring& str);
+
+inline std::wstring to_native(const std::string& str)
+{
+    return to_wide(str);
+}
+
+#else
+
+inline std::string to_native(const std::string& str)
+{
+    return str;
+}
 
 #endif
 

--- a/src/cmdline.cpp
+++ b/src/cmdline.cpp
@@ -89,21 +89,6 @@ bool CmdLineParser::parse_string(char short_opt, const char* long_opt, std::stri
     return false;
 }
 
-bool CmdLineParser::parse_path(char short_opt, const char* long_opt, std::filesystem::path& option)
-{
-    std::string str;
-    if (!parse_string(short_opt, long_opt, str))
-        return false;
-
-#ifdef _WIN32
-    option = to_wide(str);
-#else
-    option = str;
-#endif
-
-    return true;
-}
-
 bool CmdLineParser::parse_int(char short_opt, const char* long_opt, int& option)
 {
     std::string option_as_str;
@@ -212,10 +197,10 @@ const Options& CmdLineParser::parse()
 
         // By this stage, we know that this arg is some option.
         // Now we need to work out which one it is.
-        if (parse_path('i', "--input", m_options.patch_file_path))
+        if (parse_string('i', "--input", m_options.patch_file_path))
             continue;
 
-        if (parse_path('d', "--directory", m_options.patch_directory_path))
+        if (parse_string('d', "--directory", m_options.patch_directory_path))
             continue;
 
         if (parse_string('D', "--ifdef", m_options.define_macro))

--- a/src/patch.cpp
+++ b/src/patch.cpp
@@ -24,7 +24,7 @@
 
 namespace Patch {
 
-void print_header_info(std::istream& patch, PatchHeaderInfo& header_info, std::ostream& out)
+void print_header_info(std::istream& patch, const PatchHeaderInfo& header_info, std::ostream& out)
 {
     patch.seekg(header_info.patch_start);
     out << "Hmm...  Looks like a " << to_string(header_info.format) << " diff to me...\n";

--- a/src/patch.cpp
+++ b/src/patch.cpp
@@ -227,7 +227,6 @@ int process_patch(const Options& options)
     // When writing the patched file to cout - write any prompts to cerr instead.
     const bool output_to_stdout = options.out_file_path == "-";
     auto& out = output_to_stdout ? std::cerr : std::cout;
-    auto& err = std::cerr;
 
     PatchFile patch_file(options);
 


### PR DESCRIPTION
The previously attempted approach of trying to use std::filesystem::path
everywhere that mattered was proving over complicated to implement.
Instead patch now internally handles every string as utf8 and at
filesystem boundries converts the utf8 path to its wide path equivalent.

The amount of #ifdef _WIN32 used here is very ugly, and not every part
of the code which needs this done is completed here. However, a basic
test case is now passing, so this should be a good initial version.