### PR TITLE
patch: implement support for --read-only commandline option

### DIFF
--- a/include/patch/cmdline.h
+++ b/include/patch/cmdline.h
@@ -57,7 +57,7 @@ private:
     void parse_short_bool(const std::string& option);
     void parse_operand();
     void handle_newline_strategy(const std::string& strategy);
-    void handle_reject_format(const std::string& strategy);
+    void handle_reject_format(const std::string& format);
 
     int i { 1 };
     int m_argc { 0 };

--- a/include/patch/cmdline.h
+++ b/include/patch/cmdline.h
@@ -57,6 +57,7 @@ private:
     void parse_short_bool(const std::string& option);
     void parse_operand();
     void handle_newline_strategy(const std::string& strategy);
+    void handle_read_only(const std::string& handling);
     void handle_reject_format(const std::string& format);
 
     int i { 1 };

--- a/include/patch/options.h
+++ b/include/patch/options.h
@@ -21,6 +21,12 @@ struct Options {
         Default,
     };
 
+    enum class ReadOnlyHandling {
+        Warn,
+        Ignore,
+        Fail,
+    };
+
     // posix defined options
     bool save_backup { false };
     bool interpret_as_context { false };
@@ -47,6 +53,7 @@ struct Options {
     bool dry_run { false };
     NewlineOutput newline_output { NewlineOutput::Native };
     RejectFormat reject_format { RejectFormat::Default };
+    ReadOnlyHandling read_only_handling { ReadOnlyHandling::Warn };
     std::string backup_suffix;
     std::string backup_prefix;
 };

--- a/src/cmdline.cpp
+++ b/src/cmdline.cpp
@@ -132,6 +132,18 @@ void CmdLineParser::handle_newline_strategy(const std::string& strategy)
         throw cmdline_parse_error("unrecognized newline strategy " + strategy);
 }
 
+void CmdLineParser::handle_read_only(const std::string& handling)
+{
+    if (handling == "warn")
+        m_options.read_only_handling = Options::ReadOnlyHandling::Warn;
+    else if (handling == "ignore")
+        m_options.read_only_handling = Options::ReadOnlyHandling::Ignore;
+    else if (handling == "fail")
+        m_options.read_only_handling = Options::ReadOnlyHandling::Fail;
+    else
+        throw cmdline_parse_error("unrecognized read-only handling " + handling);
+}
+
 void CmdLineParser::handle_reject_format(const std::string& format)
 {
     if (format == "context")
@@ -226,6 +238,11 @@ const Options& CmdLineParser::parse()
 
         if (parse_string('\0', "--newline-output", m_buffer)) {
             handle_newline_strategy(m_buffer);
+            continue;
+        }
+
+        if (parse_string('\0', "--read-only", m_buffer)) {
+            handle_read_only(m_buffer);
             continue;
         }
 
@@ -336,6 +353,14 @@ void show_usage(std::ostream& out)
            "\n"
            "    -d, --directory <directory>\n"
            "                Change the working directory to <directory> before applying the patch file.\n"
+           "\n"
+           "    --read-only <handling>\n"
+           "                Change how to handle when the file being patched is read only. The default read-only behaviour\n"
+           "                is to 'warn'. The possible values for this flag are:\n"
+           "\n"
+           "                    warn    Warn that the file is read-only, but proceed patching it anyway.\n"
+           "                    ignore  Proceed patching without any warning issued.\n"
+           "                    fail    Fail, and refuse patching the file.\n"
            "\n"
            "    --newline-handling <handling>\n"
            "                Change how newlines are output to the patched file. The default newline behavior\n"

--- a/src/cmdline.cpp
+++ b/src/cmdline.cpp
@@ -132,14 +132,14 @@ void CmdLineParser::handle_newline_strategy(const std::string& strategy)
         throw cmdline_parse_error("unrecognized newline strategy " + strategy);
 }
 
-void CmdLineParser::handle_reject_format(const std::string& strategy)
+void CmdLineParser::handle_reject_format(const std::string& format)
 {
-    if (strategy == "context")
+    if (format == "context")
         m_options.reject_format = Options::RejectFormat::Context;
-    else if (strategy == "unified")
+    else if (format == "unified")
         m_options.reject_format = Options::RejectFormat::Unified;
     else
-        throw cmdline_parse_error("unrecognized reject format " + strategy);
+        throw cmdline_parse_error("unrecognized reject format " + format);
 }
 
 void CmdLineParser::parse_short_bool(const std::string& option_string)

--- a/src/patch.cpp
+++ b/src/patch.cpp
@@ -319,7 +319,17 @@ int process_patch(const Options& options)
         const bool fix_permissions = (old_permissions & write_perm_mask) == filesystem::perms::none;
 
         if (fix_permissions) {
-            out << "File " << output_file << " is read-only; trying to patch anyway;\n";
+            if (options.read_only_handling != Options::ReadOnlyHandling::Ignore) {
+                out << "File " << output_file << " is read-only;";
+                if (options.read_only_handling == Options::ReadOnlyHandling::Warn) {
+                    out << " trying to patch anyway\n";
+                } else {
+                    refuse_to_patch(out, mode, output_file, patch, options);
+                    had_failure = true;
+                    continue;
+                }
+            }
+
             if (!options.dry_run)
                 filesystem::permissions(output_file, old_permissions | write_perm_mask);
         }

--- a/src/patch.cpp
+++ b/src/patch.cpp
@@ -295,7 +295,7 @@ int process_patch(const Options& options)
             out << reject_writer.rejected_hunks() << " out of " << patch.hunks.size() << " hunk";
             if (patch.hunks.size() > 1)
                 out << 's';
-            std::cout << " ignored";
+            out << " ignored";
             if (!options.dry_run) {
                 const auto reject_path = options.reject_file_path.empty() ? output_file + ".rej" : options.reject_file_path;
                 out << " -- saving rejects to file " << reject_path;
@@ -386,7 +386,7 @@ int process_patch(const Options& options)
                 out << result.failed_hunks << " out of " << patch.hunks.size() << " hunk";
                 if (patch.hunks.size() > 1)
                     out << 's';
-                std::cout << reason;
+                out << reason;
                 if (!options.dry_run) {
                     const auto reject_path = options.reject_file_path.empty() ? output_file + ".rej" : options.reject_file_path;
                     out << " -- saving rejects to file " << reject_path;

--- a/tests/test_full.py
+++ b/tests/test_full.py
@@ -1609,8 +1609,8 @@ new mode 100755
         self.assertTrue(os.access('file', os.X_OK))
 
 
-    def test_read_only_file(self):
-        ''' test patching a file which is read only still applies '''
+    def test_read_only_file_default(self):
+        ''' test patching a file which is read only still applies with a warning by default '''
 
         patch = '''
 --- a/a	2022-09-18 09:59:59.586887443 +1200
@@ -1636,10 +1636,87 @@ new mode 100755
 
         ret = run_patch('patch -i diff.patch')
 
-        self.assertEqual(ret.stdout, 'File a is read-only; trying to patch anyway;\npatching file a\n')
+        self.assertEqual(ret.stdout, 'File a is read-only; trying to patch anyway\npatching file a\n')
         self.assertEqual(ret.stderr, '')
         self.assertEqual(ret.returncode, 0)
         self.assertFileEqual('a', '1\n2\n4\n')
+
+        # Ensure file permissions restored to original
+        new_mode = os.stat('a').st_mode
+        self.assertEqual(new_mode, old_mode)
+
+
+    def test_read_only_file_ignore(self):
+        ''' test patching a file which is read only still applies with no warning if ignore flag set '''
+
+        patch = '''
+--- a/a	2022-09-18 09:59:59.586887443 +1200
++++ b/a	2022-09-18 10:00:04.410912780 +1200
+@@ -1,4 +1,3 @@
+ 1
+ 2
+-3
+ 4
+'''
+        with open('diff.patch', 'w', encoding='utf8') as patch_file:
+            patch_file.write(patch)
+
+        to_patch = '1\n2\n3\n4\n'
+        with open('a', 'w', encoding='utf8') as to_patch_file:
+            to_patch_file.write(to_patch)
+
+        # Make file read-only. Keep track of old mode.
+        mode = os.stat('a').st_mode
+        ro_mask = 0o777 ^ (stat.S_IWRITE | stat.S_IWGRP | stat.S_IWOTH)
+        os.chmod('a', mode & ro_mask)
+        old_mode = os.stat('a').st_mode
+
+        ret = run_patch('patch -i diff.patch --read-only ignore')
+
+        self.assertEqual(ret.stdout, 'patching file a\n')
+        self.assertEqual(ret.stderr, '')
+        self.assertEqual(ret.returncode, 0)
+        self.assertFileEqual('a', '1\n2\n4\n')
+
+        # Ensure file permissions restored to original
+        new_mode = os.stat('a').st_mode
+        self.assertEqual(new_mode, old_mode)
+
+
+    def test_read_only_file_fail(self):
+        ''' test patching a file which is read only fails if fail option is set '''
+
+        patch = '''\
+--- a	2022-09-18 09:59:59.586887443 +1200
++++ a	2022-09-18 10:00:04.410912780 +1200
+@@ -1,4 +1,3 @@
+ 1
+ 2
+-3
+ 4
+'''
+        with open('diff.patch', 'w', encoding='utf8') as patch_file:
+            patch_file.write(patch)
+
+        to_patch = '1\n2\n3\n4\n'
+        with open('a', 'w', encoding='utf8') as to_patch_file:
+            to_patch_file.write(to_patch)
+
+        # Make file read-only. Keep track of old mode.
+        mode = os.stat('a').st_mode
+        ro_mask = 0o777 ^ (stat.S_IWRITE | stat.S_IWGRP | stat.S_IWOTH)
+        os.chmod('a', mode & ro_mask)
+        old_mode = os.stat('a').st_mode
+
+        ret = run_patch('patch -i diff.patch --read-only fail')
+
+        self.assertEqual(ret.stderr, '')
+        self.assertEqual(ret.stdout, '''File a is read-only; refusing to patch
+1 out of 1 hunk ignored -- saving rejects to file a.rej
+''')
+        self.assertEqual(ret.returncode, 1)
+        self.assertFileEqual('a', to_patch)
+        self.assertFileEqual('a.rej', patch)
 
         # Ensure file permissions restored to original
         new_mode = os.stat('a').st_mode


### PR DESCRIPTION
 Somehow I had missed that this option was a thing previously and thought
 I was more feature complete with GNU patch than I was. Add support for
 this flag, as well as some tests to go with it.
    
 Also align a error message more closely with GNU patch while we are at
 it.
