### PR TITLE
tests: add a basic test for a reversed patch

### DIFF
--- a/include/patch/system.h
+++ b/include/patch/system.h
@@ -18,6 +18,8 @@ void ensure_parent_directories(const std::string& file_path);
 
 namespace filesystem {
 
+std::string make_temp_directory();
+
 bool exists(const std::string& path);
 
 bool is_regular_file(const std::string& path);

--- a/src/system.cpp
+++ b/src/system.cpp
@@ -158,6 +158,28 @@ void chdir(const std::string& path)
 
 namespace filesystem {
 
+std::string make_temp_directory()
+{
+#ifdef _WIN32
+    std::wstring wpath = L"patch-XXXXXX";
+
+    if (_wmktemp_s(&wpath[0], wpath.size() + 1) < 0)
+        throw std::system_error(errno, std::generic_category(), "Unable to create temporary file name");
+
+    if (_wmkdir(wpath.c_str()) < 0)
+        throw std::system_error(errno, std::generic_category(), "Unable to make temporary directory");
+
+    return to_narrow(wpath);
+#else
+    std::string path = "patch-XXXXXX";
+
+    if (!mkdtemp(&path[0]))
+        throw std::system_error(errno, std::generic_category(), "Unable to make temporary directory");
+
+    return path;
+#endif
+}
+
 bool exists(const std::string& path)
 {
 #ifdef _WIN32

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -3,6 +3,7 @@
 
 include(FetchContent)
 include(GoogleTest)
+include(CheckSymbolExists)
 
 FetchContent_Declare(
   googletest
@@ -36,6 +37,21 @@ patch_add_test(test_patch
   test_strip.cpp
   test_file.cpp
 )
+
+set(CMAKE_REQUIRED_LIBRARIES "util")
+check_symbol_exists(forkpty "pty.h" HAVE_FORKPTY_PTY)
+check_symbol_exists(forkpty "util.h" HAVE_FORKPTY_UTIL)
+unset(CMAKE_REQUIRED_LIBRARIES)
+
+configure_file(src/config.h.in src/config.h)
+include_directories(${CMAKE_CURRENT_BINARY_DIR}/src)
+
+if(HAVE_FORKPTY_PTY OR HAVE_FORKPTY_UTIL)
+  add_executable(test_pty test_pty.cpp src/pty_spawn.cpp)
+  target_link_libraries(test_pty PRIVATE patch util)
+  target_include_directories(test_pty PRIVATE src)
+  add_test(NAME Patch.Pty COMMAND test_pty $<TARGET_FILE:sb_patch>)
+endif()
 
 add_executable(patch_oom
   stubs/stub_patch_oom.cpp

--- a/tests/src/config.h.in
+++ b/tests/src/config.h.in
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright 2022 Shannon Booth <shannon.ml.booth@gmail.com>
+
+#pragma once
+
+#cmakedefine HAVE_FORKPTY_PTY
+#cmakedefine HAVE_FORKPTY_UTIL

--- a/tests/src/pty_spawn.cpp
+++ b/tests/src/pty_spawn.cpp
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright 2022 Shannon Booth <shannon.ml.booth@gmail.com>
+
+#include <chrono>
+#include <config.h>
+#include <cstdlib>
+#include <patch/file.h>
+#include <patch/system.h>
+#include <poll.h>
+#include <pty_spawn.h>
+#include <stdexcept>
+#include <system_error>
+#include <unistd.h>
+
+#ifdef HAVE_FORKPTY_PTY
+#    include <pty.h>
+#elif HAVE_FORKPTY_UTIL
+#    include <util.h>
+#else
+#    error "Unknown include for forkpty"
+#endif
+
+PtySpawn::PtySpawn(int argc, char** argv)
+{
+    (void)argc;
+    pid_t pid = forkpty(&m_master, nullptr, nullptr, nullptr);
+
+    if (pid < 0)
+        throw std::system_error(errno, std::generic_category(), "Opening tty device failed");
+
+    // Child process runs patch command.
+    if (pid == 0) {
+        ::setsid();
+        ::execv(argv[0], argv);
+        throw std::system_error(errno, std::generic_category(), "Failed to exec command");
+    }
+
+    // Turn off terminal echo so that we do not get back from the spawned process what we have sent it.
+    disable_echo(m_master);
+}
+
+void PtySpawn::write(const std::string& data)
+{
+    auto ret = ::write(m_master, data.c_str(), data.size());
+    if (ret != data.size())
+        throw std::system_error(errno, std::generic_category(), "Failed to exec command");
+}
+
+std::string PtySpawn::read(std::chrono::milliseconds timeout)
+{
+    std::string buffer;
+    buffer.resize(32);
+
+    size_t offset = 0;
+
+    while (true) {
+
+        struct pollfd fds = {};
+        fds.fd = m_master;
+        fds.events = POLLIN;
+
+        int poll_result = ::poll(&fds, 1, static_cast<int>(timeout.count()));
+        if (poll_result < 0)
+            throw std::system_error(errno, std::generic_category(), "Poll failed waiting for data");
+
+        if (poll_result == 0)
+            throw std::runtime_error("Timeout waiting for data");
+
+        auto ret = ::read(m_master, &buffer[0] + offset, buffer.size() - offset);
+        if (ret <= 0) {
+            buffer.resize(offset);
+            break;
+        }
+
+        offset += ret;
+
+        if (offset >= buffer.size())
+            buffer.resize(buffer.size() * 2);
+    }
+
+    return buffer;
+}
+
+void PtySpawn::disable_echo(int fd)
+{
+    struct termios term;
+    if (tcgetattr(fd, &term) < 0)
+        throw std::system_error(errno, std::generic_category(), "Failed getting terminal attributes");
+
+    term.c_lflag &= ~(ECHO | ECHOE | ECHOK | ECHONL);
+    term.c_oflag &= ~ONLCR;
+
+    if (tcsetattr(fd, TCSANOW, &term) < 0)
+        throw std::system_error(errno, std::generic_category(), "Failed setting terminal attributes");
+}

--- a/tests/src/pty_spawn.h
+++ b/tests/src/pty_spawn.h
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright 2022 Shannon Booth <shannon.ml.booth@gmail.com>
+
+#pragma once
+
+#include <chrono>
+#include <string>
+
+class PtySpawn {
+public:
+    PtySpawn(int argc, const char* const* argv)
+        : PtySpawn(argc, const_cast<char**>(argv)) // NOLINT(cppcoreguidelines-pro-type-const-cast)
+    {
+    }
+
+    PtySpawn(int argc, char** argv);
+
+    void write(const std::string& data);
+
+    std::string read(std::chrono::milliseconds timeout = std::chrono::seconds(2));
+
+private:
+    static void disable_echo(int fd);
+
+    int m_master;
+};

--- a/tests/src/test.h
+++ b/tests/src/test.h
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright 2022 Shannon Booth <shannon.ml.booth@gmail.com>
+
+#pragma once
+
+#include <iostream>
+#include <stdexcept>
+
+#define EXPECT_EQ(lhs, rhs)                                        \
+    do {                                                           \
+        if (lhs != rhs) {                                          \
+            std::cerr << "FAIL: " << lhs << " != " << rhs << '\n'; \
+            throw std::runtime_error("Test failed");               \
+        }                                                          \
+    } while (false)

--- a/tests/test_pty.cpp
+++ b/tests/test_pty.cpp
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright 2022 Shannon Booth <shannon.ml.booth@gmail.com>
+
+#include <array>
+#include <iostream>
+#include <patch/file.h>
+#include <patch/system.h>
+#include <pty_spawn.h>
+#include <stdexcept>
+#include <test.h>
+
+static void test(const char* patch_path)
+{
+    std::array<const char*, 4> cmd { patch_path, "-i", "diff.patch", nullptr };
+
+    {
+        Patch::File file("a", std::ios_base::out);
+        file << "1\nb\n3\n";
+        file.close();
+    }
+
+    {
+        Patch::File file("diff.patch", std::ios_base::out);
+
+        file << R"(
+--- a	2022-09-27 19:32:58.112960376 +1300
++++ b	2022-09-27 19:33:04.088209645 +1300
+@@ -1,3 +1,3 @@
+ 1
+-2
++b
+ 3
+)";
+        file.close();
+    }
+
+    PtySpawn term(static_cast<int>(cmd.size()), cmd.data());
+
+    term.write("y\n");
+
+    const auto out = term.read();
+
+    EXPECT_EQ(out, R"(patching file a
+Reversed (or previously applied) patch detected! Assume -R? [n] )");
+}
+
+int main(int argc, const char* const* argv)
+{
+    if (argc != 2) {
+        std::cerr << argc << " - Wrong number of arguments given\n";
+        return 1;
+    }
+
+    std::string tmp_dir = Patch::filesystem::make_temp_directory();
+    Patch::chdir(tmp_dir);
+
+    try {
+        test(argv[1]);
+    } catch (const std::exception& e) {
+        std::cerr << e.what() << '\n';
+
+        std::string command = "rm -rf " + tmp_dir;
+        std::system(command.c_str());
+        return 1;
+    }
+}


### PR DESCRIPTION
The first C++ test which is invoking the patch binary. Invoke using pty
so that we can simulate user input on /dev/tty. Unfortunately this does
make the test less portable, but at least this is better than nothing.