### PR TITLE
patch: fix skipping of patch when prompted by user after missing file

### DIFF
--- a/src/patch.cpp
+++ b/src/patch.cpp
@@ -122,7 +122,7 @@ static std::string prompt_for_filepath(std::ostream& out)
             out << '\n';
         }
 
-        if (check_with_user("Skip this patch", out, Default::True))
+        if (check_with_user("Skip this patch?", out, Default::True))
             return "";
     }
 }
@@ -393,13 +393,18 @@ int process_patch(const Options& options)
         if (file_to_patch.empty())
             file_to_patch = prompt_for_filepath(out);
 
-        if (file_to_patch.empty()) {
-            out << "Skipping patch.\n";
-            continue;
-        }
-
         if (should_parse_body)
             parse_patch_body(patch, patch_file.file());
+
+        if (file_to_patch.empty()) {
+            out << "Skipping patch.\n"
+                << patch.hunks.size() << " out of " << patch.hunks.size() << " hunk";
+            if (patch.hunks.size() > 1)
+                out << 's';
+            out << " ignored\n";
+            had_failure = true;
+            continue;
+        }
 
         const auto output_file = output_path(options, patch, file_to_patch);
 

--- a/tests/test_pty.cpp
+++ b/tests/test_pty.cpp
@@ -141,4 +141,36 @@ The text leading up to this was:
 --------------------------
 File to patch: patching file file
 )");
+    EXPECT_EQ(term.return_code(), 0);
+}
+
+PATCH_TEST(pty_file_not_found_skip_patch)
+{
+    {
+        Patch::File file("diff.patch", std::ios_base::out);
+
+        file << R"(--- a/a	2023-01-03 11:23:35.634966282 +1300
++++ b/b	2023-01-03 11:23:41.598960625 +1300
+@@ -1,3 +1,3 @@
+ 1
+-2
++b
+ 3
+)";
+        file.close();
+    }
+
+    PtySpawn term(patch_path, { patch_path, "-i", "diff.patch", nullptr }, "some file name that does not exist!\ny\n");
+    EXPECT_EQ(term.output(), R"(can't find file to patch at input line 3
+Perhaps you should have used the -p or --strip option?
+The text leading up to this was:
+--------------------------
+|--- a/a	2023-01-03 11:23:35.634966282 +1300
+|+++ b/b	2023-01-03 11:23:41.598960625 +1300
+--------------------------
+File to patch: some file name that does not exist!: No such file or directory
+Skip this patch? [y] Skipping patch.
+1 out of 1 hunk ignored
+)");
+    EXPECT_EQ(term.return_code(), 1);
 }


### PR DESCRIPTION
We were not parsing past the patch file to skip the patch after asking the user whether we should be skipping the patch after not being able to find the file that the user has been prompted for.