### PR TITLE
cmdline: handle partially specified unambiguous long options

### DIFF
--- a/include/patch/cmdline.h
+++ b/include/patch/cmdline.h
@@ -49,7 +49,6 @@ public:
     const Options& parse();
 
 private:
-    bool parse_long_string(const char* long_opt, std::string& option);
     static int stoi(const std::string& option, const char* long_name);
 
     void parse_long_option(const std::string& option);

--- a/tests/lib/include/patch/test.h
+++ b/tests/lib/include/patch/test.h
@@ -64,16 +64,24 @@ void patch_test_error_format(const T& a)
         }                                                      \
     } while (false)
 
-#define EXPECT_THROW(statement, expected_exception)                         \
-    try {                                                                   \
-        (statement);                                                        \
-    } catch (const expected_exception&) {                                   \
-        /* nothing to do */                                                 \
-    } catch (...) {                                                         \
-        std::cerr << "FAIL: " #statement " throws an exception of type "    \
-                  << #expected_exception ", but threw a different type.\n"; \
-        throw std::runtime_error("Test failed");                            \
-    }
+#define EXPECT_THROW(statement, expected_exception)                             \
+    do {                                                                        \
+        bool patch_failed_test = false;                                         \
+        try {                                                                   \
+            (statement);                                                        \
+            std::cerr << "FAIL: " #statement " expected an exception of type "  \
+                      << #expected_exception ", but none was thrown.\n";        \
+            patch_failed_test = true;                                           \
+        } catch (const expected_exception&) {                                   \
+            /* nothing to do */                                                 \
+        } catch (...) {                                                         \
+            std::cerr << "FAIL: " #statement " throws an exception of type "    \
+                      << #expected_exception ", but threw a different type.\n"; \
+            throw std::runtime_error("Test failed");                            \
+        }                                                                       \
+        if (patch_failed_test)                                                  \
+            throw std::runtime_error("Test failed");                            \
+    } while (false);
 
 #define EXPECT_FILE_EQ(file, rhs)                                                         \
     do {                                                                                  \

--- a/tests/lib/src/test.cpp
+++ b/tests/lib/src/test.cpp
@@ -71,7 +71,7 @@ bool Test::run(const char* patch_path)
         return true;
     }
 
-    bool success = true;
+    bool success = expected != ExpectedResult::ExpectedFail;
 
     setup();
 

--- a/tests/test_cmdline.cpp
+++ b/tests/test_cmdline.cpp
@@ -171,7 +171,8 @@ TEST(cmdline_with_long_opt_set_with_equal_sign_and_no_argument)
         nullptr,
     };
 
-    EXPECT_THROW(parse_cmdline(dummy_args.size() - 1, dummy_args.data()), Patch::cmdline_parse_error);
+    auto options = parse_cmdline(dummy_args.size() - 1, dummy_args.data());
+    EXPECT_EQ(options.patch_file_path, "");
 }
 
 TEST(cmdline_with_multiple_short_options)
@@ -402,4 +403,62 @@ TEST(cmdline_boolean_followed_by_string_in_single_arg)
 
     EXPECT_TRUE(options.interpret_as_context);
     EXPECT_EQ(options.patch_file_path, "some input");
+}
+
+TEST(cmdline_boolean_followed_by_equal)
+{
+    const std::vector<const char*> dummy_args {
+        "patch",
+        "--help=",
+        nullptr,
+    };
+
+    EXPECT_THROW(parse_cmdline(dummy_args.size() - 1, dummy_args.data()), Patch::cmdline_parse_error);
+}
+
+TEST(cmdline_long_option_only_partially_specified_unambiguous)
+{
+    const std::vector<const char*> version_options {
+        "--help",
+        "--hel",
+        "--he",
+        "--h",
+    };
+
+    for (const char* option : version_options) {
+        const std::vector<const char*> dummy_args {
+            "patch",
+            option,
+            nullptr,
+        };
+
+        auto options = parse_cmdline(dummy_args.size() - 1, dummy_args.data());
+
+        EXPECT_TRUE(options.show_help);
+    }
+}
+
+TEST(cmdline_long_option_only_partially_specified_ambiguous)
+{
+    const std::vector<const char*> ambiguous_option {
+        "--reject-f",
+        "--reject-",
+        "--reject",
+        "--rejec",
+        "--reje",
+        "--rej",
+        "--re",
+        "--r",
+    };
+
+    for (const char* option : ambiguous_option) {
+        const std::vector<const char*> dummy_args {
+            "patch",
+            option,
+            "context",
+            nullptr,
+        };
+
+        EXPECT_THROW(parse_cmdline(dummy_args.size() - 1, dummy_args.data()), Patch::cmdline_parse_error);
+    }
 }


### PR DESCRIPTION
If the long option does not match anything exactly we now look for any
partial matches. If there is one, and only one match, that is selected.
Otherwise, we error out.