### PR TITLE
patch: do not use std::tmpfile to create temporary files

### DIFF
--- a/include/patch/system.h
+++ b/include/patch/system.h
@@ -4,10 +4,13 @@
 #pragma once
 
 #include <cstdint>
+#include <cstdio>
 #include <string>
 #include <vector>
 
 namespace Patch {
+
+FILE* create_temporary_file();
 
 std::string read_tty_until_enter();
 
@@ -22,6 +25,8 @@ void ensure_parent_directories(const std::string& file_path);
 namespace filesystem {
 
 bool create_directory(const std::string& path);
+
+std::string temp_directory_path();
 
 std::string make_temp_directory();
 

--- a/src/file.cpp
+++ b/src/file.cpp
@@ -59,11 +59,7 @@ File& File::operator=(File&& other) noexcept
 
 File File::create_temporary()
 {
-    FILE* file = std::tmpfile();
-    if (!file)
-        throw std::system_error(errno, std::generic_category(), "Unable to create temporary file");
-
-    return File(file);
+    return File(create_temporary_file());
 }
 
 static void copy_from(FILE* from, FILE* to)
@@ -99,17 +95,10 @@ void File::write_entire_contents_to(FILE* file)
 
 File File::create_temporary(FILE* initial_content)
 {
-    FILE* file = std::tmpfile();
-    if (!file)
-        throw std::system_error(errno, std::generic_category(), "Unable to create temporary file");
-
-    File real_file(file);
-
-    copy_from(initial_content, file);
-
-    std::rewind(file);
-
-    return real_file;
+    File file(create_temporary_file());
+    copy_from(initial_content, file.m_file);
+    std::rewind(file.m_file);
+    return file;
 }
 
 File File::create_temporary_with_content(const std::string& initial_content)

--- a/tests/test_parser.cpp
+++ b/tests/test_parser.cpp
@@ -694,7 +694,7 @@ TEST(parser_context_diff_with_changed_line)
     EXPECT_FALSE(patch.hunks[1].lines.empty());
 }
 
-TEST(parser_normal_diff_no_new_line_at_end_of_file)
+TEST(parser_normal_diff_add_no_new_line_at_end_of_file)
 {
     Patch::File patch_file = Patch::File::create_temporary_with_content(R"(0a1
 > a
@@ -707,6 +707,22 @@ TEST(parser_normal_diff_no_new_line_at_end_of_file)
     EXPECT_EQ(lines.size(), 1);
     EXPECT_EQ(lines.at(0).operation, '+');
     EXPECT_EQ(lines.at(0).line.content, "a");
+    EXPECT_EQ(lines.at(0).line.newline, Patch::NewLine::None);
+}
+
+TEST(parser_normal_diff_remove_no_new_line_at_end_of_file)
+{
+    Patch::File patch_file = Patch::File::create_temporary_with_content(R"(1d0
+< d
+\ No newline at end of file
+)");
+
+    auto patch = Patch::parse_patch(patch_file);
+    EXPECT_EQ(patch.hunks.size(), 1);
+    const auto& lines = patch.hunks.at(0).lines;
+    EXPECT_EQ(lines.size(), 1);
+    EXPECT_EQ(lines.at(0).operation, '-');
+    EXPECT_EQ(lines.at(0).line.content, "d");
     EXPECT_EQ(lines.at(0).line.newline, Patch::NewLine::None);
 }
 


### PR DESCRIPTION
tmpfile on windows unfortunately may need admin privileges to run. To
solve this problem write our own implementation of creating a temporary
file.

This should also allow us future optimisations where we can perhaps make
us of the filename to rename the temporary file, instead of needing to
copy the entire thing.
