### PR TITLE
parser: further improve error messages output by corrupted normal patch

### DIFF
--- a/include/patch/utils.h
+++ b/include/patch/utils.h
@@ -32,4 +32,9 @@ constexpr bool is_not_digit(char c)
     return !is_digit(c);
 }
 
+constexpr bool is_whitespace(char c)
+{
+    return c == ' ' || c == '\t';
+}
+
 } // namespace Patch

--- a/src/locator.cpp
+++ b/src/locator.cpp
@@ -4,13 +4,9 @@
 #include <algorithm>
 #include <patch/hunk.h>
 #include <patch/locator.h>
+#include <patch/utils.h>
 
 namespace Patch {
-
-static constexpr bool is_whitespace(char c)
-{
-    return c == ' ' || c == '\t';
-}
 
 bool matches_ignoring_whitespace(const std::string& as, const std::string& bs)
 {

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -973,12 +973,12 @@ Patch Parser::parse_normal_patch(Patch& patch)
             throw std::invalid_argument("Unable to parse normal range command: " + patch_line);
 
         for (LineNumber i = 0; i < current_hunk->old_file_range.number_of_lines; ++i) {
-            if (!get_line(patch_line, &newline) || patch_line.empty())
-                break;
+            if (!get_line(patch_line, &newline))
+                throw parser_error("unexpected end of file in patch at line " + std::to_string(m_line_number - 1));
 
-            const char c = patch_line[0];
-            if (c != '<')
+            if (patch_line.size() < 2 || patch_line[0] != '<' || !is_whitespace(patch_line[1]))
                 throw parser_error("'<' followed by space or tab expected at line " + std::to_string(m_line_number - 1) + " of patch");
+
             current_hunk->lines.emplace_back('-', Line(patch_line.substr(2, patch_line.size()), newline));
         }
 
@@ -993,12 +993,12 @@ Patch Parser::parse_normal_patch(Patch& patch)
         }
 
         for (LineNumber i = 0; i < current_hunk->new_file_range.number_of_lines; ++i) {
-            if (!get_line(patch_line, &newline) || patch_line.empty())
-                break;
+            if (!get_line(patch_line, &newline))
+                throw parser_error("unexpected end of file in patch at line " + std::to_string(m_line_number - 1));
 
-            const char c = patch_line[0];
-            if (c != '>')
+            if (patch_line.size() < 2 || patch_line[0] != '>' || !is_whitespace(patch_line[1]))
                 throw parser_error("'>' followed by space or tab expected at line " + std::to_string(m_line_number - 1) + " of patch");
+
             current_hunk->lines.emplace_back('+', Line(patch_line.substr(2, patch_line.size()), newline));
         }
 

--- a/tests/test_normal.cpp
+++ b/tests/test_normal.cpp
@@ -61,3 +61,84 @@ d 3
     EXPECT_EQ(process.stderr_data(), std::string(patch_path) + ": **** '<' followed by space or tab expected at line 3 of patch\n");
     EXPECT_EQ(process.return_code(), 2);
 }
+
+PATCH_TEST(normal_patch_with_tab)
+{
+    {
+        Patch::File file("diff.patch", std::ios_base::out);
+
+        file << R"(2c2
+< 2
+---
+>	c
+)";
+        file.close();
+    }
+
+    {
+        Patch::File file("to_patch", std::ios_base::out);
+
+        file << "1\n2\n3\n";
+        file.close();
+    }
+
+    Process process(patch_path, { patch_path, "-i", "diff.patch", "-n", "to_patch", nullptr });
+
+    EXPECT_EQ(process.stdout_data(), "patching file to_patch\n");
+    EXPECT_EQ(process.stderr_data(), "");
+    EXPECT_EQ(process.return_code(), 0);
+}
+
+PATCH_TEST(normal_patch_corrupted_no_space_or_tab)
+{
+    {
+        Patch::File file("diff.patch", std::ios_base::out);
+
+        file << R"(2c2
+< 2
+---
+>	c
+)";
+        file.close();
+    }
+
+    {
+        Patch::File file("to_patch", std::ios_base::out);
+
+        file << "1\n2\n3\n";
+        file.close();
+    }
+
+    Process process(patch_path, { patch_path, "-i", "diff.patch", "-n", "to_patch", nullptr });
+
+    EXPECT_EQ(process.stdout_data(), "patching file to_patch\n");
+    EXPECT_EQ(process.stderr_data(), "");
+    EXPECT_EQ(process.return_code(), 0);
+}
+
+PATCH_TEST(normal_patch_corrupted_missing_lines)
+{
+
+    {
+        Patch::File file("diff.patch", std::ios_base::out);
+
+        file << R"(2c2
+< 2
+---
+)";
+        file.close();
+    }
+
+    {
+        Patch::File file("to_patch", std::ios_base::out);
+
+        file << "1\n2\n3\n";
+        file.close();
+    }
+
+    Process process(patch_path, { patch_path, "-i", "diff.patch", "-n", "to_patch", nullptr });
+
+    EXPECT_EQ(process.stdout_data(), "patching file to_patch\n");
+    EXPECT_EQ(process.stderr_data(), std::string(patch_path) + ": **** unexpected end of file in patch at line 3\n");
+    EXPECT_EQ(process.return_code(), 2);
+}


### PR DESCRIPTION
Cover off some more possibilities for corrupted normal patches, making sure that we report a sane error if that goes wrong.