### PR TITLE
patch: fix being unable to add a file in a normal patch

### DIFF
--- a/include/patch/hunk.h
+++ b/include/patch/hunk.h
@@ -14,8 +14,8 @@ namespace Patch {
 using LineNumber = int64_t;
 
 struct Range {
-    LineNumber start_line { 0 };
-    LineNumber number_of_lines { 0 };
+    LineNumber start_line { -1 };
+    LineNumber number_of_lines { -1 };
 };
 
 enum class Format {

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -642,9 +642,9 @@ bool Parser::parse_patch_header(Patch& patch, PatchHeaderInfo& header_info, int 
     }
 
     if (patch.operation == Operation::Change) {
-        if (patch.new_file_path == "/dev/null")
+        if (hunk.new_file_range.start_line == 0)
             patch.operation = Operation::Delete;
-        else if (patch.old_file_path == "/dev/null")
+        else if (hunk.old_file_range.start_line == 0)
             patch.operation = Operation::Add;
     }
 

--- a/src/patch.cpp
+++ b/src/patch.cpp
@@ -338,13 +338,15 @@ int process_patch(const Options& options)
 
         bool looks_like_adding_file = false;
 
-        if (patch.old_file_path == "/dev/null") {
+        if (patch.operation == Operation::Add) {
             // This should only happen if the file has already been patched!
-            if (!file_to_patch.empty()) {
+            if (options.file_to_patch.empty() && !file_to_patch.empty()) {
                 out << "The next patch would create the file " << file_to_patch << ",\n"
                     << "which already exists!\n";
-            } else {
+            } else if (file_to_patch.empty()) {
                 file_to_patch = patch.new_file_path;
+                looks_like_adding_file = true;
+            } else {
                 looks_like_adding_file = true;
             }
         }

--- a/tests/test_normal.cpp
+++ b/tests/test_normal.cpp
@@ -142,3 +142,23 @@ PATCH_TEST(normal_patch_corrupted_missing_lines)
     EXPECT_EQ(process.stderr_data(), std::string(patch_path) + ": **** unexpected end of file in patch at line 3\n");
     EXPECT_EQ(process.return_code(), 2);
 }
+
+PATCH_TEST(normal_patch_add_file)
+{
+
+    {
+        Patch::File file("diff.patch", std::ios_base::out);
+
+        file << R"(0a1
+> 1
+)";
+        file.close();
+    }
+
+    Process process(patch_path, { patch_path, "-i", "diff.patch", "-n", "a", nullptr });
+
+    EXPECT_EQ(process.stdout_data(), "patching file a\n");
+    EXPECT_EQ(process.stderr_data(), "");
+    EXPECT_EQ(process.return_code(), 0);
+    EXPECT_FILE_EQ("a", "1\n");
+}


### PR DESCRIPTION
Our approach of just using the filename of /dev/null to determine whether we are adding a file or not does not work for normal patch as it does not contain any patch header with a filename in it.

There is some code here that is starting to look pretty nasty, but I'm not entirely sure yet of the behaviour which we intend to implement, so that should be fine for now.