### PR TITLE
patch: add support for --batch and --force options for prerequisites

### DIFF
--- a/include/patch/options.h
+++ b/include/patch/options.h
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-// Copyright 2022 Shannon Booth <shannon.ml.booth@gmail.com>
+// Copyright 2022-2023 Shannon Booth <shannon.ml.booth@gmail.com>
 
 #pragma once
 
@@ -46,6 +46,7 @@ struct Options {
 
     // non posix defined
     bool force { false };
+    bool batch { false };
     bool show_help { false };
     bool show_version { false };
     bool interpret_as_unified { false };

--- a/src/cmdline.cpp
+++ b/src/cmdline.cpp
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-// Copyright 2022 Shannon Booth <shannon.ml.booth@gmail.com>
+// Copyright 2022-2023 Shannon Booth <shannon.ml.booth@gmail.com>
 
 #include <algorithm>
 #include <array>
@@ -31,7 +31,7 @@ struct Option {
     HasArgument has_argument;
 };
 
-const std::array<Option, 25> s_switches { {
+const std::array<Option, 26> s_switches { {
     { 'B', "--prefix", HasArgument::Yes },
     { 'D', "--ifdef", HasArgument::Yes },
     { 'F', "--fuzz", HasArgument::Yes },
@@ -49,6 +49,7 @@ const std::array<Option, 25> s_switches { {
     { 'o', "--output", HasArgument::Yes },
     { 'p', "--strip", HasArgument::Yes },
     { 'r', "--reject-file", HasArgument::Yes },
+    { 't', "--batch", HasArgument::No },
     { 'u', "--unified", HasArgument::No },
     { 'v', "--version", HasArgument::No },
     { 'z', "--suffix", HasArgument::Yes },
@@ -347,6 +348,9 @@ void CmdLineParser::process_option(int short_name, const std::string& value)
     case 'r':
         m_options.reject_file_path = value;
         break;
+    case 't':
+        m_options.batch = true;
+        break;
     case 'u':
         m_options.interpret_as_unified = true;
         break;
@@ -442,6 +446,9 @@ void show_usage(std::ostream& out)
            "\n"
            "    -f, --force\n"
            "                Do not prompt for input, try to apply patch as given.\n"
+           "\n"
+           "    -t, --batch\n"
+           "                Do not apply patch file if content given by 'Prereq' is missing in the original file.\n"
            "\n"
            "    -b, --backup\n"
            "                Before writing to the patched file, make a backup of the file that will be written\n"

--- a/tests/test_prerequisite.cpp
+++ b/tests/test_prerequisite.cpp
@@ -90,6 +90,7 @@ PATCH_TEST(prerequisite_is_not_met_continue_success)
     PtySpawn term(patch_path, { patch_path, "-i", "diff.patch", nullptr }, "y\n");
 
     EXPECT_EQ(term.output(), "This file doesn't appear to be the version-1.2.4 version -- patch anyway? [n] patching file a\n");
+    EXPECT_EQ(term.return_code(), 0);
 }
 
 PATCH_TEST(prerequisite_is_not_met_abort)
@@ -128,4 +129,82 @@ PATCH_TEST(prerequisite_is_not_met_abort)
     PtySpawn term(patch_path, { patch_path, "-i", "diff.patch", nullptr }, "\n");
 
     EXPECT_EQ(term.output(), "This file doesn't appear to be the version-1.2.4 version -- patch anyway? [n] " + std::string(patch_path) + ": **** aborted\n");
+}
+
+PATCH_TEST(prerequisite_is_not_met_force)
+{
+    {
+        Patch::File file("diff.patch", std::ios_base::out);
+
+        file << R"(Prereq: version-1.2.4
+--- a	2023-01-18 18:46:47.745632233 +1300
++++ b	2023-01-18 18:46:53.339025728 +1300
+@@ -3,5 +3,5 @@
+ 2
+ 3
+ 4
+-5
++4
+ 6
+)";
+        file.close();
+    }
+
+    {
+        Patch::File file("a", std::ios_base::out);
+
+        file << R"(version-1.2.3
+1
+2
+3
+4
+5
+6
+)";
+        file.close();
+    }
+
+    Process process(patch_path, { patch_path, "-i", "diff.patch", "--force", nullptr });
+    EXPECT_EQ(process.stdout_data(), "Warning: this file doesn't appear to be the version-1.2.4 version -- patching anyway.\npatching file a\n");
+    EXPECT_EQ(process.stderr_data(), "");
+    EXPECT_EQ(process.return_code(), 0);
+}
+
+PATCH_TEST(prerequisite_is_not_met_batch)
+{
+    {
+        Patch::File file("diff.patch", std::ios_base::out);
+
+        file << R"(Prereq: version-1.2.4
+--- a	2023-01-18 18:46:47.745632233 +1300
++++ b	2023-01-18 18:46:53.339025728 +1300
+@@ -3,5 +3,5 @@
+ 2
+ 3
+ 4
+-5
++4
+ 6
+)";
+        file.close();
+    }
+
+    {
+        Patch::File file("a", std::ios_base::out);
+
+        file << R"(version-1.2.3
+1
+2
+3
+4
+5
+6
+)";
+        file.close();
+    }
+
+    Process process(patch_path, { patch_path, "-i", "diff.patch", "--batch", nullptr });
+    EXPECT_EQ(process.stderr_data(), std::string(patch_path) + ": **** This file doesn't appear to be the version-1.2.4 version -- aborting.\n");
+    EXPECT_EQ(process.stdout_data(), "");
+    EXPECT_EQ(process.return_code(), 2);
 }


### PR DESCRIPTION
--batch being an entirely new option altogether which we did not previously support! It seems from reading the man page of patch that --batch is used for more than just this, but this should serve as a good initial go at it.