### PR TITLE
patch: implement options to enable/disable backups on mismatch

### DIFF
--- a/include/patch/options.h
+++ b/include/patch/options.h
@@ -52,6 +52,7 @@ struct Options {
     bool interpret_as_unified { false };
     bool verbose { false };
     bool dry_run { false };
+    bool backup_if_mismatch { true };
     NewlineOutput newline_output { NewlineOutput::Native };
     RejectFormat reject_format { RejectFormat::Default };
     ReadOnlyHandling read_only_handling { ReadOnlyHandling::Warn };

--- a/src/cmdline.cpp
+++ b/src/cmdline.cpp
@@ -31,7 +31,7 @@ struct Option {
     HasArgument has_argument;
 };
 
-const std::array<Option, 26> s_switches { {
+const std::array<Option, 28> s_switches { {
     { 'B', "--prefix", HasArgument::Yes },
     { 'D', "--ifdef", HasArgument::Yes },
     { 'F', "--fuzz", HasArgument::Yes },
@@ -58,6 +58,8 @@ const std::array<Option, 26> s_switches { {
     { CHAR_MAX + 3, "--reject-format", HasArgument::Yes },
     { CHAR_MAX + 4, "--verbose", HasArgument::No },
     { CHAR_MAX + 5, "--dry-run", HasArgument::No },
+    { CHAR_MAX + 6, "--backup-if-mismatch", HasArgument::No },
+    { CHAR_MAX + 7, "--no-backup-if-mismatch", HasArgument::No },
 } };
 
 } // namespace
@@ -375,6 +377,12 @@ void CmdLineParser::process_option(int short_name, const std::string& value)
     case CHAR_MAX + 5:
         m_options.dry_run = true;
         break;
+    case CHAR_MAX + 6:
+        m_options.backup_if_mismatch = true;
+        break;
+    case CHAR_MAX + 7:
+        m_options.backup_if_mismatch = false;
+        break;
     default:
         break;
     }
@@ -454,6 +462,15 @@ void show_usage(std::ostream& out)
            "    -b, --backup\n"
            "                Before writing to the patched file, make a backup of the file that will be written\n"
            "                to. The output file with be given the filename suffix '.orig'.\n"
+           "\n"
+           "    --backup-if-mismatch\n"
+           "                Automatically make a backup of the file to be written to (as if given '--backup') if\n"
+           "                it is determined that the patch will apply with an offset or fuzz factor. Defaults\n"
+           "                to 'true'.\n"
+           "\n"
+           "    --no-backup-if-mismatch\n"
+           "                Only apply a backup of the file to be written to if told to do so by the '--backup'\n"
+           "                option even if the patch is determined to not apply perfectly.\n"
            "\n"
            "    -B, --prefix <prefix>\n"
            "                Add <prefix> to the beginning of backup file names.\n"

--- a/src/patch.cpp
+++ b/src/patch.cpp
@@ -493,7 +493,7 @@ int process_patch(const Options& options)
             tmp_out_file.write_entire_contents_to(stdout);
         } else {
             if (!options.dry_run) {
-                if (options.save_backup || (!result.all_hunks_applied_perfectly && !result.was_skipped))
+                if (options.save_backup || (!result.all_hunks_applied_perfectly && !result.was_skipped && options.backup_if_mismatch))
                     backup.make_backup_for(output_file);
 
                 // Ensure that parent directories exist if we are adding a file.


### PR DESCRIPTION
Add the options to enable or disable the behaviour of applying backups on mismatch. The '--backup-if-mimatch' option is kind of useless at the moment since it defaults to true, and the only way to turn it off is the '--no-backup-if-mismatch' option. However, this should change as soon as the '--posix' option is introduced which will be changing some of these defaults!