### PR TITLE
patch: implement --remove-empty-files with --posix handling

### DIFF
--- a/include/patch/options.h
+++ b/include/patch/options.h
@@ -27,8 +27,8 @@ struct Options {
         Fail,
     };
 
-    enum class BackupIfMismatchHandling {
-        Default,
+    enum class OptionalBool {
+        Unset,
         Yes,
         No,
     };
@@ -59,7 +59,8 @@ struct Options {
     bool verbose { false };
     bool dry_run { false };
     bool posix { false };
-    BackupIfMismatchHandling backup_if_mismatch { BackupIfMismatchHandling::Default };
+    OptionalBool backup_if_mismatch { OptionalBool::Unset };
+    OptionalBool remove_empty_files { OptionalBool::Unset };
     NewlineOutput newline_output { NewlineOutput::Native };
     RejectFormat reject_format { RejectFormat::Default };
     ReadOnlyHandling read_only_handling { ReadOnlyHandling::Warn };

--- a/src/patch.cpp
+++ b/src/patch.cpp
@@ -493,7 +493,7 @@ int process_patch(const Options& options)
             tmp_out_file.write_entire_contents_to(stdout);
         } else {
             if (!options.dry_run) {
-                if (options.save_backup || (!result.all_hunks_applied_perfectly && !result.was_skipped && options.backup_if_mismatch == Options::BackupIfMismatchHandling::Yes))
+                if (options.save_backup || (!result.all_hunks_applied_perfectly && !result.was_skipped && options.backup_if_mismatch == Options::OptionalBool::Yes))
                     backup.make_backup_for(output_file);
 
                 // Ensure that parent directories exist if we are adding a file.
@@ -548,7 +548,7 @@ int process_patch(const Options& options)
 
                 // Clean up the file if it looks like it was removed.
                 // NOTE: we check for file size for the degenerate case that the file is a removal, but has nothing left.
-                if (patch.new_file_path == "/dev/null") {
+                if (options.remove_empty_files == Options::OptionalBool::Yes && patch.new_file_path == "/dev/null") {
                     if (filesystem::file_size(output_file) == 0) {
                         if (!options.dry_run)
                             remove_file_and_empty_parent_folders(output_file);

--- a/tests/test_cmdline.cpp
+++ b/tests/test_cmdline.cpp
@@ -472,8 +472,8 @@ TEST(cmdline_long_option_only_partially_specified_ambiguous)
         { "--rejec", "option '--rejec' is ambiguous; possibilities: '--reject-file' '--reject-format'" },
         { "--reje", "option '--reje' is ambiguous; possibilities: '--reject-file' '--reject-format'" },
         { "--rej", "option '--rej' is ambiguous; possibilities: '--reject-file' '--reject-format'" },
-        { "--re", "option '--re' is ambiguous; possibilities: '--reverse' '--reject-file' '--read-only' '--reject-format'" },
-        { "--r", "option '--r' is ambiguous; possibilities: '--reverse' '--reject-file' '--read-only' '--reject-format'" },
+        { "--re", "option '--re' is ambiguous; possibilities: '--remove-empty-files' '--reverse' '--reject-file' '--read-only' '--reject-format'" },
+        { "--r", "option '--r' is ambiguous; possibilities: '--remove-empty-files' '--reverse' '--reject-file' '--read-only' '--reject-format'" },
     };
 
     for (const auto& data : test_data) {


### PR DESCRIPTION
Functionally the only real difference here to our existing logic is that the removal of empty files now does not happen if the --posix option is set.