### PR TITLE
cmdline: add support for POSIXLY_CORRECT environment variable

### DIFF
--- a/include/patch/cmdline.h
+++ b/include/patch/cmdline.h
@@ -50,6 +50,7 @@ public:
 
 private:
     void apply_posix_defaults();
+    void apply_environment_defaults();
 
     static int stoi(const std::string& option, const std::string& description);
 

--- a/src/cmdline.cpp
+++ b/src/cmdline.cpp
@@ -295,9 +295,16 @@ const Options& CmdLineParser::parse()
             parse_short_option(option_string);
     }
 
+    apply_environment_defaults();
     apply_posix_defaults();
 
     return m_options;
+}
+
+void CmdLineParser::apply_environment_defaults()
+{
+    if (!m_options.posix)
+        m_options.posix = std::getenv("POSIXLY_CORRECT") != nullptr;
 }
 
 void CmdLineParser::apply_posix_defaults()

--- a/tests/lib/include/patch/test.h
+++ b/tests/lib/include/patch/test.h
@@ -12,6 +12,10 @@
 
 namespace Patch {
 
+void unset_env(const char* name);
+
+void set_env(const char* name, const char* value);
+
 template<class T, typename std::enable_if<!std::is_enum<T> {}>::type* = nullptr>
 void test_error_format(const T& a)
 {

--- a/tests/lib/include/patch/test.h
+++ b/tests/lib/include/patch/test.h
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-// Copyright 2022 Shannon Booth <shannon.ml.booth@gmail.com>
+// Copyright 2022-2023 Shannon Booth <shannon.ml.booth@gmail.com>
 
 #pragma once
 
@@ -10,14 +10,16 @@
 #include <string>
 #include <type_traits>
 
+namespace Patch {
+
 template<class T, typename std::enable_if<!std::is_enum<T> {}>::type* = nullptr>
-void patch_test_error_format(const T& a)
+void test_error_format(const T& a)
 {
     std::cerr << a;
 }
 
 template<class T, typename std::enable_if<std::is_enum<T> {}>::type* = nullptr>
-void patch_test_error_format(const T& a)
+void test_error_format(const T& a)
 {
     std::cerr << static_cast<typename std::underlying_type<T>::type>(a);
 }
@@ -31,7 +33,7 @@ public:
     do {                                                                                                        \
         if (!(condition)) {                                                                                     \
             std::cerr << "FAIL: " __FILE__ << ":" << __LINE__ << ": 'EXPECT_TRUE(" << #condition ")' failed\n"; \
-            throw test_assertion_failure("Test failed");                                                        \
+            throw Patch::test_assertion_failure("Test failed");                                                 \
         }                                                                                                       \
     } while (false)
 
@@ -39,7 +41,7 @@ public:
     do {                                                                                                         \
         if ((condition)) {                                                                                       \
             std::cerr << "FAIL: " __FILE__ << ":" << __LINE__ << ": 'EXPECT_FALSE(" << #condition ")' failed\n"; \
-            throw test_assertion_failure("Test failed");                                                         \
+            throw Patch::test_assertion_failure("Test failed");                                                  \
         }                                                                                                        \
     } while (false)
 
@@ -49,11 +51,11 @@ public:
         if ((lhs) == (rhs)) {                                                    \
             std::cerr << "FAIL: " __FILE__ << ":" << __LINE__ << ": ";           \
             std::cerr << "'EXPECT_NE(" << #lhs << ", " << #rhs << ")' failed, "; \
-            patch_test_error_format(lhs);                                        \
+            Patch::test_error_format(lhs);                                       \
             std::cerr << " == ";                                                 \
-            patch_test_error_format(rhs);                                        \
+            Patch::test_error_format(rhs);                                       \
             std::cerr << '\n';                                                   \
-            throw test_assertion_failure("Test failed");                         \
+            throw Patch::test_assertion_failure("Test failed");                  \
         }                                                                        \
     } while (false)
 
@@ -63,11 +65,11 @@ public:
         if ((lhs) != (rhs)) {                                                    \
             std::cerr << "FAIL: " __FILE__ << ":" << __LINE__ << ": ";           \
             std::cerr << "'EXPECT_EQ(" << #lhs << ", " << #rhs << ")' failed, "; \
-            patch_test_error_format(lhs);                                        \
+            Patch::test_error_format(lhs);                                       \
             std::cerr << " != ";                                                 \
-            patch_test_error_format(rhs);                                        \
+            Patch::test_error_format(rhs);                                       \
             std::cerr << '\n';                                                   \
-            throw test_assertion_failure("Test failed");                         \
+            throw Patch::test_assertion_failure("Test failed");                  \
         }                                                                        \
     } while (false)
 
@@ -91,15 +93,15 @@ public:
             std::cerr << "FAIL: " __FILE__ << ":" << __LINE__ << ": "                     \
                       << #statement " throws an exception of type "                       \
                       << #expected_exception ", but threw a different type.\n";           \
-            throw test_assertion_failure("Test failed");                                  \
+            throw Patch::test_assertion_failure("Test failed");                           \
         }                                                                                 \
         if (patch_failed_test)                                                            \
-            throw test_assertion_failure("Test failed");                                  \
+            throw Patch::test_assertion_failure("Test failed");                           \
         if (!expected_msg.empty() && patch_error_msg != (msg)) {                          \
             std::cerr << "FAIL: " __FILE__ << ":" << __LINE__ << ": "                     \
                       << #statement " expected an error message of: \""                   \
                       << (msg) << "\", but instead got: \"" << patch_error_msg << "\"\n"; \
-            throw test_assertion_failure("Test failed");                                  \
+            throw Patch::test_assertion_failure("Test failed");                           \
         }                                                                                 \
     } while (false)
 
@@ -131,7 +133,7 @@ void register_test(std::string name, std::function<void(const char*)> test);
         TEST_REGISTER_HELPER(name)                                      \
         ()                                                              \
         {                                                               \
-            register_test(#name, TEST_FUNCTION_NAME(name));             \
+            Patch::register_test(#name, TEST_FUNCTION_NAME(name));      \
         }                                                               \
     };                                                                  \
     static const TEST_REGISTER_HELPER(name) TEST_REGISTER_HELPER(name); \
@@ -145,9 +147,11 @@ void register_test(std::string name, std::function<void(const char*)> test);
         TEST_REGISTER_HELPER(name)                                      \
         ()                                                              \
         {                                                               \
-            register_test(#name, TEST_FUNCTION_NAME(name));             \
+            Patch::register_test(#name, TEST_FUNCTION_NAME(name));      \
         }                                                               \
     };                                                                  \
     static const TEST_REGISTER_HELPER(name) TEST_REGISTER_HELPER(name); \
     /* NOLINTNEXTLINE(readability-function-cognitive-complexity) */     \
     static void TEST_FUNCTION_NAME(name)()
+
+} // namespace Patch

--- a/tests/lib/src/test.cpp
+++ b/tests/lib/src/test.cpp
@@ -1,10 +1,12 @@
 // SPDX-License-Identifier: BSD-3-Clause
-// Copyright 2022 Shannon Booth <shannon.ml.booth@gmail.com>
+// Copyright 2022-2023 Shannon Booth <shannon.ml.booth@gmail.com>
 
 #include <chrono>
 #include <patch/system.h>
 #include <patch/test.h>
 #include <patch/utils.h>
+
+namespace Patch {
 
 class Test {
 public:
@@ -220,9 +222,11 @@ void register_test(std::string name, const std::function<void()>& test_function)
     });
 }
 
+} // namespace Patch
+
 int main(int argc, const char* const* argv)
 {
-    auto& r = runner();
+    auto& r = Patch::runner();
 
     // List tests
     if (argc == 1) {

--- a/tests/test_basic.cpp
+++ b/tests/test_basic.cpp
@@ -698,6 +698,12 @@ PATCH_TEST(no_remove_file_posix)
     remove_file(patch_path, false, { "--posix" });
 }
 
+PATCH_TEST(no_remove_file_posix_as_env)
+{
+    Patch::set_env("POSIXLY_CORRECT", "1");
+    remove_file(patch_path, false, {});
+}
+
 PATCH_TEST(remove_file_successfully_posix_and_remove_flag)
 {
     remove_file(patch_path, true, { "--posix", "--remove-empty-files" });
@@ -1529,8 +1535,14 @@ PATCH_TEST(backup_if_mismatch_not_done_with_flag)
 PATCH_TEST(COMPAT_XFAIL_backup_if_mismatch_not_done_posix)
 {
     // NOTE: This appears to be a bug with GNU patch.
-    //       Setting POSIXLY_CORRECT appears to work, but --posix flag does not!
+    //       Setting POSIXLY_CORRECT appears to work (see below), but --posix flag does not!
     no_backup_if_mismatch(patch_path, { "--posix" });
+}
+
+PATCH_TEST(backup_if_mismatch_not_done_posix_env)
+{
+    Patch::set_env("POSIXLY_CORRECT", "1");
+    no_backup_if_mismatch(patch_path, {});
 }
 
 PATCH_TEST(backup_multiple_files_only_backs_up_first)

--- a/tests/test_defines.cpp
+++ b/tests/test_defines.cpp
@@ -160,7 +160,7 @@ PATCH_TEST(defines_add_remove)
 #endif
 }
 )");
-    } catch (const test_assertion_failure&) {
+    } catch (const Patch::test_assertion_failure&) {
         EXPECT_FILE_EQ("file.cpp", R"(int main()
 {
 #ifndef TEST_PATCH


### PR DESCRIPTION
This serves as the alternative way of putting patch into POSIX mode.