### PR TITLE
patch: begin adding initial support for handling symlinks

### DIFF
--- a/include/patch/system.h
+++ b/include/patch/system.h
@@ -58,6 +58,12 @@ enum class perms : unsigned {
     unknown = 0xFFFF,
 };
 
+inline bool is_symlink(uint32_t mode)
+{
+    constexpr uint32_t symlink_mode = 0120000;
+    return (mode & symlink_mode) == symlink_mode;
+}
+
 inline perms operator&(perms left, perms right)
 {
     return static_cast<perms>(static_cast<unsigned>(left) & static_cast<unsigned>(right));

--- a/src/patch.cpp
+++ b/src/patch.cpp
@@ -462,7 +462,7 @@ int process_patch(const Options& options)
         if (!patch.prerequisite.empty() && !has_prerequisite(input_lines, patch.prerequisite))
             check_prerequisite_handling(out, options, patch.prerequisite);
 
-        out << patch_operation(options) << " file " << format_filename(output_file);
+        out << patch_operation(options) << (filesystem::is_symlink(patch.new_file_mode) ? " symbolic link " : " file ") << format_filename(output_file);
 
         if (patch.operation == Operation::Rename) {
             if (file_to_patch == output_file) {

--- a/tests/lib/src/test.cpp
+++ b/tests/lib/src/test.cpp
@@ -120,6 +120,7 @@ bool Test::run(const char* patch_path, bool is_compat)
         if (expected != ExpectedResult::ExpectedFail) {
             std::cerr << e.what() << '\n';
             std::cerr << m_name << " FAILED!\n";
+            success = false;
         } else {
             success = true;
         }

--- a/tests/test_basic.cpp
+++ b/tests/test_basic.cpp
@@ -2147,3 +2147,28 @@ PATCH_TEST(reversed_patch_batch)
 
     EXPECT_FILE_EQ("a", "1\n2\n3\n");
 }
+
+PATCH_TEST(basic_add_symlink_file_to_stdout)
+{
+    {
+        Patch::File file("diff.patch", std::ios_base::out);
+
+        file << R"(
+diff --git a/b b/b
+new file mode 120000
+index 0000000..2e65efe
+--- /dev/null
++++ b/b
+@@ -0,0 +1 @@
++a
+\ No newline at end of file
+)";
+        file.close();
+    }
+
+    Process process(patch_path, { patch_path, "-i", "diff.patch", "-o-", nullptr });
+
+    EXPECT_EQ(process.stdout_data(), "a");
+    EXPECT_EQ(process.stderr_data(), "patching symbolic link - (read from b)\n");
+    EXPECT_EQ(process.return_code(), 0);
+}


### PR DESCRIPTION
git patches seem to have support for symlinks. From what I can tell,
this is signalled by the mode of the patch file.

For now, only add support for the "symbollic link" prompt which is given
when given a symlink patch. Soon, we should also handle actually adding
the symlink itself!