### PR TITLE
parser: factor some functions to make use of line parser

### DIFF
--- a/include/patch/parser.h
+++ b/include/patch/parser.h
@@ -43,6 +43,39 @@ private:
     File& m_file;
 };
 
+class LineParser {
+public:
+    explicit LineParser(const std::string& line)
+        : m_current(line.cbegin())
+        , m_end(line.cend())
+    {
+    }
+
+    bool is_eof() const;
+
+    char peek() const;
+
+    char consume();
+
+    bool consume_specific(char c);
+
+    bool consume_specific(const char* chars);
+
+    bool consume_uint();
+
+    bool consume_line_number(LineNumber& output);
+
+    std::string::const_iterator current() const { return m_current; }
+    std::string::const_iterator end() const { return m_end; }
+
+    std::string parse_quoted_string();
+
+private:
+    std::string::const_iterator m_current;
+    std::string::const_iterator m_end;
+};
+
+
 Patch parse_patch(File& file, Format format = Format::Unknown, int strip = -1);
 
 bool parse_unified_range(Hunk& hunk, const std::string& line);

--- a/include/patch/parser.h
+++ b/include/patch/parser.h
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-// Copyright 2022 Shannon Booth <shannon.ml.booth@gmail.com>
+// Copyright 2022-2023 Shannon Booth <shannon.ml.booth@gmail.com>
 
 #pragma once
 
@@ -70,6 +70,8 @@ public:
     void parse_file_line(int strip, std::string& path, std::string* timestamp = nullptr);
 
     void parse_git_header_name(Patch& patch, int strip);
+
+    bool parse_git_extended_info(Patch& patch, int strip);
 
 private:
     std::string::const_iterator m_current;

--- a/include/patch/parser.h
+++ b/include/patch/parser.h
@@ -65,23 +65,21 @@ public:
 
     bool consume_line_number(LineNumber& output);
 
-    std::string::const_iterator current() const { return m_current; }
-    std::string::const_iterator end() const { return m_end; }
-
     std::string parse_quoted_string();
+
+    void parse_file_line(int strip, std::string& path, std::string* timestamp = nullptr);
+
+    void parse_git_header_name(Patch& patch, int strip);
 
 private:
     std::string::const_iterator m_current;
     std::string::const_iterator m_end;
 };
 
-
 Patch parse_patch(File& file, Format format = Format::Unknown, int strip = -1);
 
 bool parse_unified_range(Hunk& hunk, const std::string& line);
 bool parse_normal_range(Hunk& hunk, const std::string& line);
-
-void parse_file_line(const std::string& input, int strip, std::string& path, std::string* timestamp = nullptr);
 
 std::string strip_path(const std::string& path, int amount);
 std::string parse_path(const std::string& input, int strip);

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -23,7 +23,6 @@ public:
     explicit LineParser(const std::string& line)
         : m_current(line.cbegin())
         , m_end(line.cend())
-        , m_line(line)
     {
     }
 
@@ -98,6 +97,7 @@ public:
 
     std::string parse_quoted_string()
     {
+        const auto begin = m_current;
         std::string output;
 
         consume_specific('"');
@@ -112,7 +112,7 @@ public:
                 char c = consume();
                 switch (c) {
                 case '\0':
-                    throw std::invalid_argument("Invalid unterminated \\ in quoted path " + m_line);
+                    throw std::invalid_argument("Invalid unterminated \\ in quoted path " + std::string(begin, m_end));
                 case '\\':
                     output += '\\';
                     break;
@@ -152,7 +152,7 @@ public:
                     break;
                 }
                 default:
-                    throw std::invalid_argument("Invalid or unsupported escape character in path " + m_line);
+                    throw std::invalid_argument("Invalid or unsupported escape character in path " + std::string(begin, m_current));
                 }
             } else {
                 // Normal case - a character of the path we can just add to our output.
@@ -160,13 +160,12 @@ public:
             }
         }
 
-        throw std::invalid_argument("Failed to find terminating \" when parsing " + m_line);
+        throw std::invalid_argument("Failed to find terminating \" when parsing " + std::string(begin, m_current));
     }
 
 private:
     std::string::const_iterator m_current;
     std::string::const_iterator m_end;
-    const std::string& m_line;
 };
 
 void parse_file_line(const std::string& input, int strip, std::string& path, std::string* timestamp)

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -957,23 +957,23 @@ Patch Parser::parse_normal_patch(Patch& patch)
             break;
 
         patch.hunks.emplace_back();
-        auto current_hunk = &patch.hunks.back();
-        if (!parse_normal_range(*current_hunk, patch_line))
+        auto& current_hunk = patch.hunks.back();
+        if (!parse_normal_range(current_hunk, patch_line))
             throw std::invalid_argument("Unable to parse normal range command: " + patch_line);
 
-        for (LineNumber i = 0; i < current_hunk->old_file_range.number_of_lines; ++i) {
+        for (LineNumber i = 0; i < current_hunk.old_file_range.number_of_lines; ++i) {
             if (!get_line(patch_line, &newline))
                 throw parser_error("unexpected end of file in patch at line " + std::to_string(m_line_number - 1));
 
             if (patch_line.size() < 2 || patch_line[0] != '<' || !is_whitespace(patch_line[1]))
                 throw parser_error("'<' followed by space or tab expected at line " + std::to_string(m_line_number - 1) + " of patch");
 
-            current_hunk->lines.emplace_back('-', Line(patch_line.substr(2, patch_line.size()), newline));
+            current_hunk.lines.emplace_back('-', Line(patch_line.substr(2, patch_line.size()), newline));
         }
 
         if (m_file.peek() == '\\') {
             get_line(patch_line, &newline);
-            current_hunk->lines.back().line.newline = NewLine::None;
+            current_hunk.lines.back().line.newline = NewLine::None;
         }
 
         // Expect --- if 'c' command
@@ -981,19 +981,19 @@ Patch Parser::parse_normal_patch(Patch& patch)
             get_line(patch_line, &newline);
         }
 
-        for (LineNumber i = 0; i < current_hunk->new_file_range.number_of_lines; ++i) {
+        for (LineNumber i = 0; i < current_hunk.new_file_range.number_of_lines; ++i) {
             if (!get_line(patch_line, &newline))
                 throw parser_error("unexpected end of file in patch at line " + std::to_string(m_line_number - 1));
 
             if (patch_line.size() < 2 || patch_line[0] != '>' || !is_whitespace(patch_line[1]))
                 throw parser_error("'>' followed by space or tab expected at line " + std::to_string(m_line_number - 1) + " of patch");
 
-            current_hunk->lines.emplace_back('+', Line(patch_line.substr(2, patch_line.size()), newline));
+            current_hunk.lines.emplace_back('+', Line(patch_line.substr(2, patch_line.size()), newline));
         }
 
         if (m_file.peek() == '\\') {
             get_line(patch_line, &newline);
-            current_hunk->lines.back().line.newline = NewLine::None;
+            current_hunk.lines.back().line.newline = NewLine::None;
         }
     }
     return patch;

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -914,7 +914,10 @@ Patch Parser::parse_unified_patch(Patch& patch)
                 // to parse the next hunk, otherwise return the end of
                 // this patch.
                 auto pos = m_file.tellg();
-                if (!get_line(line) || !parse_unified_range(hunk, line)) {
+                if (!get_line(line))
+                    return patch;
+
+                if (!parse_unified_range(hunk, line)) {
                     --m_line_number;
                     m_file.seekg(pos);
                     return patch;

--- a/tests/test_strip.cpp
+++ b/tests/test_strip.cpp
@@ -5,6 +5,12 @@
 #include <patch/test.h>
 #include <stdexcept>
 
+static void parse_file_line(const std::string& line, int strip, std::string& path, std::string* timestamp = nullptr)
+{
+    Patch::LineParser parser(line);
+    parser.parse_file_line(strip, path, timestamp);
+}
+
 TEST(strip_linux_path)
 {
     EXPECT_EQ(Patch::strip_path("/my/path/for/test/purposes.txt", 0), "/my/path/for/test/purposes.txt");
@@ -52,9 +58,9 @@ TEST(strip_quoted_string_bad)
 {
     std::string path;
 
-    EXPECT_THROW(Patch::parse_file_line("\"path/with unterminated comma", -1, path), std::invalid_argument);
-    EXPECT_THROW(Patch::parse_file_line("\"secondUnterminatedCommaButAfterBackslash\\", -1, path), std::invalid_argument);
-    EXPECT_THROW(Patch::parse_file_line("\"badEscapeChar\\l\"", -1, path), std::invalid_argument);
+    EXPECT_THROW(parse_file_line("\"path/with unterminated comma", -1, path), std::invalid_argument);
+    EXPECT_THROW(parse_file_line("\"secondUnterminatedCommaButAfterBackslash\\", -1, path), std::invalid_argument);
+    EXPECT_THROW(parse_file_line("\"badEscapeChar\\l\"", -1, path), std::invalid_argument);
 }
 
 TEST(strip_quoted_string_good)
@@ -63,45 +69,45 @@ TEST(strip_quoted_string_good)
     std::string timestamp;
 
     path.clear();
-    Patch::parse_file_line("someInput", -1, path, &timestamp);
+    parse_file_line("someInput", -1, path, &timestamp);
     EXPECT_EQ(path, "someInput");
     EXPECT_EQ(timestamp, "");
 
     path.clear();
-    Patch::parse_file_line("\"some spaced input\"", -1, path, &timestamp);
+    parse_file_line("\"some spaced input\"", -1, path, &timestamp);
     EXPECT_EQ(path, "some spaced input");
     EXPECT_EQ(timestamp, "");
 
     path.clear();
-    Patch::parse_file_line(R"("with backslash \\ escape char")", 0, path, &timestamp);
+    parse_file_line(R"("with backslash \\ escape char")", 0, path, &timestamp);
     EXPECT_EQ(path, "with backslash \\ escape char");
     EXPECT_EQ(timestamp, "");
 
     path.clear();
-    Patch::parse_file_line(R"("with quote \" escape char")", 0, path, &timestamp);
+    parse_file_line(R"("with quote \" escape char")", 0, path, &timestamp);
     EXPECT_EQ(path, "with quote \" escape char");
     EXPECT_EQ(timestamp, "");
 
     // Octal simple
     path.clear();
-    Patch::parse_file_line(R"("\110\145\154\154\157\054\040\167\157\162\154\144\041\040\061\062\063")", 0, path, &timestamp);
+    parse_file_line(R"("\110\145\154\154\157\054\040\167\157\162\154\144\041\040\061\062\063")", 0, path, &timestamp);
     EXPECT_EQ(path, "Hello, world! 123");
     EXPECT_EQ(timestamp, "");
 
     // Octal escape codes (+ ASCII char)
     path.clear();
-    Patch::parse_file_line(R"("\327\251\327\234\327\225\327\235 \327\242\327\225\327\234\327\235!")", 0, path, &timestamp);
+    parse_file_line(R"("\327\251\327\234\327\225\327\235 \327\242\327\225\327\234\327\235!")", 0, path, &timestamp);
     EXPECT_EQ(path, "שלום עולם!");
     EXPECT_EQ(timestamp, "");
 
     // Octal escape codes, not all 3 chars
     path.clear();
-    Patch::parse_file_line(R"("\110\145\154\154\157\054\40cruel \167\157\162\154\144\041\40\061\62\063123")", 0, path, &timestamp);
+    parse_file_line(R"("\110\145\154\154\157\054\40cruel \167\157\162\154\144\041\40\061\62\063123")", 0, path, &timestamp);
     EXPECT_EQ(path, "Hello, cruel world! 123123");
     EXPECT_EQ(timestamp, "");
 
     path.clear();
-    Patch::parse_file_line(R"("quoted string \\ then \" timestamp"	2022-06-10 19:28:11.018017172 +1200)", 0, path, &timestamp);
+    parse_file_line(R"("quoted string \\ then \" timestamp"	2022-06-10 19:28:11.018017172 +1200)", 0, path, &timestamp);
     EXPECT_EQ(path, "quoted string \\ then \" timestamp");
     EXPECT_EQ(timestamp, "\t2022-06-10 19:28:11.018017172 +1200"); // NOTE: in future we may want leading space trimmed.
 }
@@ -113,37 +119,37 @@ TEST(strip_standard_path)
 
     // Nothing
     path.clear();
-    Patch::parse_file_line("a/file.txt", -1, path, &timestamp);
+    parse_file_line("a/file.txt", -1, path, &timestamp);
     EXPECT_EQ(path, "file.txt");
     EXPECT_EQ(timestamp, "");
 
     // Trailing space
     path.clear();
-    Patch::parse_file_line("a/file.txt   2022-06-10 19:28:11.018017172 +1200", -1, path, &timestamp);
+    parse_file_line("a/file.txt   2022-06-10 19:28:11.018017172 +1200", -1, path, &timestamp);
     EXPECT_EQ(path, "file.txt");
     EXPECT_EQ(timestamp, "  2022-06-10 19:28:11.018017172 +1200"); // NOTE: in future we may want leading space trimmed.
 
     // Trailing tab
     path.clear();
-    Patch::parse_file_line("a/file.txt\t2022-06-10 19:28:11.018017172 +1200", -1, path, &timestamp);
+    parse_file_line("a/file.txt\t2022-06-10 19:28:11.018017172 +1200", -1, path, &timestamp);
     EXPECT_EQ(path, "file.txt");
     EXPECT_EQ(timestamp, "2022-06-10 19:28:11.018017172 +1200");
 
     // Space with no timestamp
     path.clear();
     timestamp.clear();
-    Patch::parse_file_line("b/a file name\t", -1, path, &timestamp);
+    parse_file_line("b/a file name\t", -1, path, &timestamp);
     EXPECT_EQ(path, "a file name");
     EXPECT_EQ(timestamp, "");
 
     // Space with timestamp
     path.clear();
-    Patch::parse_file_line("b/a file name\t2022-06-10 19:28:11.018017172 +1200", -1, path, &timestamp);
+    parse_file_line("b/a file name\t2022-06-10 19:28:11.018017172 +1200", -1, path, &timestamp);
     EXPECT_EQ(path, "a file name");
     EXPECT_EQ(timestamp, "2022-06-10 19:28:11.018017172 +1200");
 
     // Empty path
-    Patch::parse_file_line("", -1, path, &timestamp);
+    parse_file_line("", -1, path, &timestamp);
     EXPECT_EQ(path, "");
     EXPECT_EQ(timestamp, "");
 }


### PR DESCRIPTION
In particular, this has the nice side effect of slightly simplifying
parse_git_header_name to not have a dead check for the git header.

We are also able to remove LineParser::end() and LineParser::current()
with these changes.

Finally, this allows us to get rid of the substr with magic number
checks when parsing file names.