### PR TITLE
locator: correctly reject patches adding a file for non-empty files 

### DIFF
--- a/include/patch/locator.h
+++ b/include/patch/locator.h
@@ -29,6 +29,8 @@ struct Location {
     LineNumber offset { -1 };
 };
 
+LineNumber expected_line_number(const Hunk& hunk);
+
 Location locate_hunk(const std::vector<Line>& content, const Hunk& hunk, bool ignore_whitespace = false, LineNumber offset = 0, LineNumber max_fuzz = 2);
 
 bool matches_ignoring_whitespace(const std::string& as, const std::string& bs);

--- a/src/applier.cpp
+++ b/src/applier.cpp
@@ -167,7 +167,7 @@ static void print_hunk_statistics(std::ostream& out, size_t hunk_num, bool skipp
         }
         out << ".\n";
     } else {
-        out << hunk.old_file_range.start_line + offset_old_lines_to_new << ".\n";
+        out << expected_line_number(hunk) + offset_old_lines_to_new << ".\n";
     }
 }
 

--- a/src/locator.cpp
+++ b/src/locator.cpp
@@ -80,7 +80,7 @@ bool matches(const Line& line1, const Line& line2, bool ignore_whitespace)
     return matches_ignoring_whitespace(line1.content, line2.content);
 }
 
-static LineNumber expected_line_number(const Hunk& hunk)
+LineNumber expected_line_number(const Hunk& hunk)
 {
     auto line = hunk.old_file_range.start_line;
     if (hunk.old_file_range.number_of_lines == 0)


### PR DESCRIPTION
This corrects the actual logic needed to fix the:
`applier_add_file_but_file_already_exits_with_conflicts` test.

We just need to also add an informational message about when this case
is detected.