### PR TITLE
patch: do not issue spurious warning removing a file in dry-run

### DIFF
--- a/include/patch/file.h
+++ b/include/patch/file.h
@@ -110,6 +110,8 @@ public:
 
     std::string read_all_as_string();
 
+    uintmax_t size();
+
 private:
     static FILE* cfile_open_impl(const std::string& path, std::ios_base::openmode mode);
 

--- a/include/patch/system.h
+++ b/include/patch/system.h
@@ -113,8 +113,6 @@ void permissions(const std::string& path, perms permissions);
 
 perms get_permissions(const std::string& path);
 
-uintmax_t file_size(const std::string& path);
-
 uintmax_t file_size(FILE* file);
 
 } // namespace filesystem

--- a/include/patch/system.h
+++ b/include/patch/system.h
@@ -115,6 +115,8 @@ perms get_permissions(const std::string& path);
 
 uintmax_t file_size(const std::string& path);
 
+uintmax_t file_size(FILE* file);
+
 } // namespace filesystem
 
 #ifdef _WIN32

--- a/src/file.cpp
+++ b/src/file.cpp
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-// Copyright 2022 Shannon Booth <shannon.ml.booth@gmail.com>
+// Copyright 2022-2024 Shannon Booth <shannon.ml.booth@gmail.com>
 
 #include <array>
 #include <cstdio>
@@ -232,6 +232,12 @@ std::string File::read_all_as_string()
     }
 
     return content;
+}
+
+uintmax_t File::size()
+{
+    fflush(m_file, "Unable to flush file before determining its size");
+    return filesystem::file_size(m_file);
 }
 
 } // namespace Patch

--- a/src/system.cpp
+++ b/src/system.cpp
@@ -478,33 +478,6 @@ uintmax_t file_size(FILE* file)
     return buf.st_size;
 }
 
-uintmax_t file_size(const std::string& path)
-{
-#ifdef _WIN32
-    WIN32_FILE_ATTRIBUTE_DATA data;
-
-    if (!GetFileAttributesExW(to_native(path).c_str(), GetFileExInfoStandard, &data))
-        throw std::system_error(GetLastError(), std::system_category(), "Unable to determine file size for " + path);
-
-    if (data.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY)
-        throw std::system_error(std::make_error_code(std::errc::is_a_directory), path + " is a directory, unable to determine file size");
-
-    return static_cast<uintmax_t>(data.nFileSizeHigh) << 32 | data.nFileSizeLow;
-#else
-    struct stat buf;
-    if (::stat(path.c_str(), &buf) != 0)
-        throw std::system_error(errno, std::generic_category(), "Unable to determine file size for " + path);
-
-    if (S_ISDIR(buf.st_mode))
-        throw std::system_error(std::make_error_code(std::errc::is_a_directory), path + " is a directory, unable to determine file size");
-
-    if (!S_ISREG(buf.st_mode))
-        throw std::system_error(std::make_error_code(std::errc::not_supported), path + " is not a regular file, unable to determine file size");
-
-    return static_cast<uintmax_t>(buf.st_size);
-#endif
-}
-
 } // namespace filesystem
 
 #ifdef _WIN32

--- a/src/system.cpp
+++ b/src/system.cpp
@@ -469,6 +469,15 @@ perms get_permissions(const std::string& path)
 #endif
 }
 
+uintmax_t file_size(FILE* file)
+{
+    struct stat buf;
+    if (fstat(fileno(file), &buf) != 0)
+        throw std::system_error(errno, std::generic_category(), "Unable to fstat file");
+
+    return buf.st_size;
+}
+
 uintmax_t file_size(const std::string& path)
 {
 #ifdef _WIN32

--- a/tests/test_basic.cpp
+++ b/tests/test_basic.cpp
@@ -399,6 +399,32 @@ Hunk #1 FAILED at 1.
     EXPECT_FALSE(Patch::filesystem::exists("1.orig"));
 }
 
+PATCH_TEST(basic_patch_dry_run_remove_file)
+{
+    {
+        Patch::File file("diff.patch", std::ios_base::out);
+        file << R"(
+--- a
++++ /dev/null
+@@ -1 +0,0 @@
+-1
+)";
+    }
+
+    std::string to_patch = "1\n";
+    {
+        Patch::File file("a", std::ios_base::out);
+        file << to_patch;
+    }
+
+    Process process(patch_path, { patch_path, "-i", "diff.patch", "--dry-run", nullptr });
+
+    EXPECT_EQ(process.stdout_data(), "checking file a\n");
+    EXPECT_EQ(process.stderr_data(), "");
+    EXPECT_EQ(process.return_code(), 0);
+    EXPECT_FILE_EQ("a", "1\n");
+}
+
 PATCH_TEST(set_patch_file)
 {
     {


### PR DESCRIPTION
Since dry run was not writing to the output file, the file size was
being determined as non-empty. To fix this, simply check for this on the
temporary file which has been written to, even on a dry run.